### PR TITLE
Add ZF metadata to module manifest

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -17,7 +17,7 @@ param (
     [string] $LogLevel = "minimal",
 
     [Parameter()]
-    [string] $ZfModuleVersion = "1.0.2",
+    [string] $ZfModuleVersion = "1.0.6",
 
     [Parameter()]
     [version] $InvokeBuildModuleVersion = "5.12.1"

--- a/module/ZeroFailed.Deploy.Azure.psd1
+++ b/module/ZeroFailed.Deploy.Azure.psd1
@@ -90,7 +90,7 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-        # Tags = @()
+        Tags = @("ZeroFailed")
 
         # A URL to the license for this module.
         LicenseUri = 'https://github.com/zerofailed/ZeroFailed.Deploy.Azure/blob/main/LICENSE'
@@ -114,6 +114,18 @@ PrivateData = @{
         ExternalModuleDependencies = @()
 
     } # End of PSData hashtable
+
+    # ZeroFailed metadata
+    ZeroFailed = @{
+        ExtensionDependencies = @(
+            @{
+                # Assume latest stable version
+                Name = "ZeroFailed.Deploy.Common"
+                GitRepository = "https://github.com/zerofailed/ZeroFailed.Deploy.Common"
+                Process = "tasks/deploy.process.ps1"
+            }
+        )
+    }
 
 } # End of PrivateData hashtable
 


### PR DESCRIPTION
This is now the preferred way for extensions to declare their dependencies (see https://github.com/zerofailed/ZeroFailed/pull/6)