### PR TITLE
Update documentation

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -1,0 +1,149 @@
+ZeroFailed.Deploy.Azure - Reference Sheet
+
+<!-- START_GENERATED_HELP -->
+
+## Application Deployments
+
+This group contains functionality for deploying applications to Azure App Service and integrates with the environment-specific configuration management features.
+
+### Properties
+
+| Name                                       | Default Value | ENV Override                                | Description                                                                                                                  |
+| ------------------------------------------ | ------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `AppServiceAppsToDeploy`                   | @()           |                                             | Deploys the specified ZIP packages to Azure App Service. See [note below](#appserviceappstodeploy) for configuration syntax. |
+| `SkipAppServiceAppDeployment`              | $false        | `ZF_DEPLOY_SKIP_APP_SERVICE_DEPLOYMENT`     | When true, any configured App Service deployments will be skipped.                                                           |
+| `AppServiceRequiresTemporaryNetworkAccess` | $false        | `ZF_DEPLOY_APP_SERVICE_TEMP_NETWORK_ACCESS` | When true, a temporary AppService firewall rule will be created to give the deployment process access to the App Service.    |
+
+#### AppServiceAppsToDeploy
+
+This property is configured using the following structure:
+
+```powershell
+$AppServiceAppsToDeploy = @(
+    @{
+        appServiceName = { $deploymentConfig.frontEndAppServiceName }   # Using the scripblock syntax enables lazy-evaluation
+        resourceGroupName = { $deploymentConfig.resourceGroupName }
+        zipPackagePath = $frontEndZipPackagePath                        # This variable will be evaluation on initialisation (e.g. a parameter on the entrypoint script)
+    }
+    @{
+        appServiceName = { $deploymentConfig.backEndAppServiceName }
+        resourceGroupName = { $deploymentConfig.resourceGroupName }
+        zipPackagePath = $backEndZipPackagePath
+    }
+)
+```
+
+***NOTE**: The ZIP package should be a valid deployment package for Azure App Service.*
+
+### Tasks
+
+| Name                          | Description                           |
+| ----------------------------- | ------------------------------------- |
+| `deployAppServiceZipPackages` | Deploy Azure App Service ZIP packages |
+
+## ARM Deployments
+
+This group contains features for managing Azure Resource Manager deployments (using Bicep or JSON templates) and integrates with the environment-specific configuration management features.
+
+### Properties
+
+| Name                      | Default Value | ENV Override                       | Description                                                                                                                                                                                         |
+| ------------------------- | ------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RequiredArmDeployments`  | @()           |                                    | Details the ARM deployments that need to be run for the deployment process. See [note below](#requiredarmdeployments) for configuration syntax.                                                     |
+| `SkipArmDeployments`      | $false        | `ZF_DEPLOY_SKIP_ARM_DEPLOYMENTS`   | When true, skips any configured ARM deployments.                                                                                                                                                    |
+| `ZF_ArmDeploymentOutputs` | @{}           | `ZF_DEPLOY_ARM_DEPLOYMENT_OUTPUTS` | A script-scoped variable containing the outputs from any ARM deployments that will be available to the rest of the deployment process. Available for overriding as part of niche testing scenarios. |
+
+#### RequiredArmDeployments
+
+This property is configured using the following structure:
+
+```powershell
+$RequiredArmDeployments = @(
+    @{
+        templatePath = 'my-template.bicep'
+        resourceGroupName = { $deploymentConfig.resourceGroupName }     # Using the scripblock syntax enables lazy-evaluation
+        location = 'uksouth'
+        # This extension uses a convention whereby configuration settings are assumed to match ARM deployment parameters.
+        # This value overrides this behaviour by removing any config settings not required for ARM deployment, or that
+        # have an empty value so the template parameter's default value can be used.
+        configKeysToIgnore = @(
+            "RequiredConfiguration"
+            "azureLocation"
+            "azureSubscriptionId"
+            "azureTenantId"
+            "resourceGroupName"
+        )
+    }
+)
+```
+
+### Tasks
+
+| Name                 | Description                         |
+| -------------------- | ----------------------------------- |
+| `deployArmTemplates` | Runs the specified ARM deployments. |
+
+## Monitoring
+
+This group contains functionality for monitoring-related deployment tasks.
+
+### Properties
+
+| Name                                     | Default Value | ENV Override                                            | Description                                                        |
+| ---------------------------------------- | ------------- | ------------------------------------------------------- | ------------------------------------------------------------------ |
+| `SkipCreateAppInsightsReleaseAnnotation` | $false        | `ZF_DEPLOY_SKIP_CREATE_APP_INSIGHTS_RELEASE_ANNOTATION` | When true, an App Insights release annotation will not be created. |
+
+### Tasks
+
+| Name                                 | Description                               |
+| ------------------------------------ | ----------------------------------------- |
+| `createAppInsightsReleaseAnnotation` | Create an App Insights release annotation |
+
+## Security
+
+This group contains features for security-related deployment tasks.
+
+### Properties
+
+| Name                                      | Default Value | ENV Override                                | Description                                                                                                                                                                                                                                          |
+| ----------------------------------------- | ------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EnableTemporaryNetworkAccess`            | $false        | `ZF_DEPLOY_ENABLE_TEMPORARY_NETWORK_ACCESS` | When true, enables the functionality for applying temporary network access rules for Azure resources.                                                                                                                                                |
+| `SkipConnectAzure`                        | $false        | `ZF_DEPLOY_SKIP_CONNECTAZURE`               | When true, configuring the Azure connection context will be skipped.                                                                                                                                                                                 |
+| `SkipConnectAzureCli`                     | $true         | `ZF_DEPLOY_SKIP_CONNECTAZURE_CLI`           | When set to true, configuring the Azure CLI connection context will be skipped.                                                                                                                                                                      |
+| `SkipConnectAzurePowerShell`              | $false        | `ZF_DEPLOY_SKIP_CONNECTAZURE_PS`            | When set to true, configuring the Azure PowerShell connection context will be skipped.                                                                                                                                                               |
+| `SkipGetDeploymentIdentity`               | $true         | `ZF_DEPLOY_SKIP_GET_DEPLOYMENT_IDENTITY`    | When true, skips the lookup for the PrincipalId of the current Azure PowerShell identity context.                                                                                                                                                    |
+| `TemporaryNetworkAccessRequiredResources` | @()           |                                             | Defines the resources that require temporary network access rules. This is a list of Azure resources that require temporary network access rules to be applied. See [note below](#temporarynetworkaccessrequiredresources) for configuration syntax. |
+
+#### TemporaryNetworkAccessRequiredResources
+
+This property is configured using the following structure:
+
+```powershell
+$TemporaryNetworkAccessRequiredResources = @(
+    @{
+        ResourceType = '<resource-type>'                                # See below for support resource types
+        ResourceGroupName = { $deploymentConfig.resourceGroupName }     # Using the scripblock syntax enables lazy-evaluation
+        Name = { $deploymentConfig.keyVaultName }
+    }
+)
+```
+
+Supported resource types are:
+- KeyVault
+- SqlServer
+- StorageAccount
+- WebApp
+- WebAppScm
+
+
+### Tasks
+
+| Name                           | Description                                                                                      |
+| ------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `connectAzure`                 | Configures up the Azure PowerShell and/or Azure CLI connection context for the deployment        |
+| `enableTemporaryNetworkAccess` | Apply temporary network access rules to the configured Azure resources.                          |
+| `getDeploymentIdentity`        | Derive the current user's ObjectId (aka PrincipalId) using the current Azure PowerShell context. |
+| `removeTemporaryNetworkAccess` | Remove temporary network access rules from the configured Azure resources.                       |
+
+
+<!-- END_GENERATED_HELP -->

--- a/README.md
+++ b/README.md
@@ -1,26 +1,56 @@
 # ZeroFailed.Deploy.Azure
 
+[![Build Status](https://github.com/zerofailed/ZeroFailed.Deploy.Azure/actions/workflows/build.yml/badge.svg)](https://github.com/zerofailed/ZeroFailed.Deploy.Azure/actions/workflows/build.yml)  
+[![GitHub Release](https://img.shields.io/github/release/zerofailed/ZeroFailed.Deploy.Azure.svg)](https://github.com/zerofailed/ZeroFailed.Deploy.Azure/releases)  
+[![PowerShell Gallery Version](https://img.shields.io/powershellgallery/v/Endjin.ZeroFailed.Build?color=blue)](https://www.powershellgallery.com/packages/ZeroFailed.Deploy.Azure)  
+[![License](https://img.shields.io/github/license/zerofailed/ZeroFailed.Deploy.Azure.svg)](https://github.com/zerofailed/ZeroFailed.Deploy.Azure/blob/main/LICENSE)  
+
 A [ZeroFailed](https://github.com/zerofailed/ZeroFailed) extension that provides deployment features targetted at the Azure cloud platform.
 
 ## Overview
 
-| Component Type | Included | Notes               |
-|----------------|----------|---------------------|
-| Tasks          | yes      | |
-| Functions      | yes      | |
+| Component Type | Included | Notes                                                                                                                                                           |
+| -------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tasks          | yes      |                                                                                                                                                                 |
+| Functions      | yes      |                                                                                                                                                                 |
 | Processes      | no       | Designed to be compatible with the default process provided by the [ZeroFailed.Deploy.Common](https://github.com/zerofailed/ZeroFailed.Deploy.Common) extension |
 
 For more information about the different component types, please refer to the [ZeroFailed documentation](https://github.com/zerofailed/ZeroFailed/blob/main/README.md#extensions).
 
-This extension consists of the following feature groups, click the links to see their documentation:
+This extension consists of the following feature groups, refer to the [HELP page](./HELP.md) for more details.
 
 - ARM deployments
 - Application deployment
 - Monitoring integrations
 - Security
 
+The diagram below shows the discrete features and when they run as part of the default build process provided by [ZeroFailed.Deploy.Common](https://github.com/zerofailed/ZeroFailed.Deploy.Common).
+
+```mermaid
+kanban
+    init
+        connectAzure[Init Azure connections]
+        getDepId[Get current identity details]
+    provision
+        deployArm[Run ARM/Bicep deployments]
+    deploy
+        setFw[Set Temp PaaS firewall rules]
+        depAppSvcZip[Deploy ZIP to AppService]
+        aiRelAnnot[Create AppInsights Release Annotation]
+        undoFw[Revert Temp PaaS firewall rules]
+    test
+```
+
+## Pre-Requisites
+
+Using this extension requires the following components to be installed:
+
+- [Azure PowerShell modules](https://www.powershellgallery.com/packages/Az/)
+- [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+
 ## Dependencies
 
-| Extension                | Reference Type | Version |
-|--------------------------|----------------|---------|
-| ZeroFailed.Deploy.Common | git            | `main`  |
+| Extension                                                                          | Reference Type | Version |
+| ---------------------------------------------------------------------------------- | -------------- | ------- |
+| [ZeroFailed.Deploy.Common](https://github.com/zerofailed/ZeroFailed.Deploy.Common) | git            | `main`  |
+| [ZeroFailed.DevOps.Common](https://github.com/zerofailed/ZeroFailed.DevOps.Common) | git            | `main`  |

--- a/module/tasks/apps.properties.ps1
+++ b/module/tasks/apps.properties.ps1
@@ -3,16 +3,10 @@
 # </copyright>
 
 # Synopsis: Deploys the specified ZIP packages to Azure App Service.
-# This should be an array of hashtables, each specifying an App Service to deploy to.
-# Each hashtable must contain:
-# - appServiceName: The name of the App Service to deploy to.
-# - resourceGroupName: The name of the resource group containing the App Service.
-# - zipPackagePath: The path to the ZIP package to deploy.
-# The ZIP package should be a valid deployment package for the App Service.
-# Supports deferred evaluation of each hashtable within the array, but not the array itself.
 $AppServiceAppsToDeploy = @()
 
 # Synopsis: When true, any configured App Service deployments will be skipped.
 $SkipAppServiceAppDeployment = [Convert]::ToBoolean((property ZF_DEPLOY_SKIP_APP_SERVICE_DEPLOYMENT $false))
 
+#Synopsis: When true, a temporary AppService firewall rule will be created to give the deployment process access to the App Service.
 $AppServiceRequiresTemporaryNetworkAccess = [Convert]::ToBoolean((property ZF_DEPLOY_APP_SERVICE_TEMP_NETWORK_ACCESS $false))

--- a/module/tasks/arm.properties.ps1
+++ b/module/tasks/arm.properties.ps1
@@ -5,8 +5,8 @@
 # Synopsis: When true, skips any configured ARM deployments. Defaults to false.
 $SkipArmDeployments = [Convert]::ToBoolean((property ZF_DEPLOY_SKIP_ARM_DEPLOYMENTS $false))
 
-# Synopsis: Details the ARM deployments that need to be run for the deployment process. **TODO: CONFIG docs**
-$RequiredArmDeployments = property ZF_DEPLOY_REQUIRED_ARM_DEPLOYMENTS @()
+# Synopsis: Details the ARM deployments that need to be run for the deployment process.
+$RequiredArmDeployments = @()
 
 # Synopsis: A script-scoped variable containing the outputs from any ARM deployments that will be available to the rest of the deployment process. Available for overriding as part of niche testing scenarios.
 $script:ZF_ArmDeploymentOutputs = property ZF_DEPLOY_ARM_DEPLOYMENT_OUTPUTS @()

--- a/module/tasks/monitoring.tasks.ps1
+++ b/module/tasks/monitoring.tasks.ps1
@@ -5,7 +5,7 @@
 . $PSScriptRoot/monitoring.properties.ps1
 
 # Synopsis: Create an App Insights release annotation
-task createAppInsightsReleaseAnnotation -If { !$SkipCreateAppInsightsReleaseAnnotation } `
+task createAppInsightsReleaseAnnotation -If { !$SkipCreateAppInsightsReleaseAnnotation -and $IsAzureDevOpsRelease } `
                                         -After DeployCore `
                                         -Before PostDeploy {
 

--- a/module/tasks/security.properties.ps1
+++ b/module/tasks/security.properties.ps1
@@ -2,11 +2,20 @@
 # Copyright (c) Endjin Limited. All rights reserved.
 # </copyright>
 
-# Synopsis: When true, skips the lookup for the PrincipalId of the current Azure PowerShell identity context. Default is true.
+# Synopsis: When true, skips the lookup for the PrincipalId of the current Azure PowerShell identity context.
 $SkipGetDeploymentIdentity = [Convert]::ToBoolean((property ZF_DEPLOY_SKIP_GET_DEPLOYMENT_IDENTITY $true))
 
-# Synopsis: When true, enables the functionality for applying temporary network access rules for Azure resources. Default is false.
+# Synopsis: When true, enables the functionality for applying temporary network access rules for Azure resources.
 $EnableTemporaryNetworkAccess = [Convert]::ToBoolean((property ZF_DEPLOY_ENABLE_TEMPORARY_NETWORK_ACCESS $false))
 
-# Synopsis: Defines the resources that require temporary network access rules. This is a list of Azure resources that require temporary network access rules to be applied. Default is an empty list.
-$TemporaryNetworkAccessRequiredResources = property ZF_DEPLOY_TEMPORARY_NETWORK_ACCESS_REQUIRED_RESOURCES @()
+# Synopsis: Defines the resources that require temporary network access rules. This is a list of Azure resources that require temporary network access rules to be applied.
+$TemporaryNetworkAccessRequiredResources = @()
+
+# Synopsis: When true, configuring the Azure connection context will be skipped.
+$SkipConnectAzure = [Convert]::ToBoolean((property ZF_DEPLOY_SKIP_CONNECTAZURE $false))
+
+# Synopsis: When set to true, configuring the Azure PowerShell connection context will be skipped.
+$SkipConnectAzurePowerShell = [Convert]::ToBoolean((property ZF_DEPLOY_SKIP_CONNECTAZURE_PS $false))
+
+# Synopsis: When set to true, configuring the Azure CLI connection context will be skipped.
+$SkipConnectAzureCli = [Convert]::ToBoolean((property ZF_DEPLOY_SKIP_CONNECTAZURE_CLI $true))

--- a/module/tasks/security.tasks.ps1
+++ b/module/tasks/security.tasks.ps1
@@ -38,3 +38,12 @@ task removeTemporaryNetworkAccess -If {$EnableTemporaryNetworkAccess} -After Pos
     Assert-TemporaryNetworkAccessRules -RequiredResources $TemporaryNetworkAccessRequiredResources -Revoke
     Remove-Item variable:/__TEMPORARY_NETWORK_ACCESS_RULES__ -Force -ErrorAction Ignore
 }
+
+# Synopsis: Configures up the Azure PowerShell and/or Azure CLI connection context for the deployment
+task connectAzure -If { !$SkipConnectAzure } -After InitCore readConfiguration,{
+    Connect-CorvusAzure `
+        -SubscriptionId $script:DeploymentConfig.azureSubscriptionId `
+        -AadTenantId $script:DeploymentConfig.AzureTenantId `
+        -SkipAzPowerShell:$SkipConnectAzurePowerShell `
+        -SkipAzureCli:$SkipConnectAzureCli
+}


### PR DESCRIPTION
- Updates to README
- Added task & property reference info
- Migrated `connectAzure` task from 'ZeroFailed.Deploy.Common' extension
- Update condition for `createAppInsightsReleaseAnnotation` to only run for ADO classic release pipelines