### PR TITLE
Enhancements to temporary PaaS firewall management feature

### DIFF
--- a/module/tasks/security.tasks.ps1
+++ b/module/tasks/security.tasks.ps1
@@ -4,6 +4,8 @@
 
 . $PSScriptRoot/security.properties.ps1
 
+$_TEMP_NET_ACCESS_FLAG_NAME = '__TEMPORARY_NETWORK_ACCESS_RULES__'
+
 # Synopsis: Derive the current user's ObjectId (aka PrincipalId) using the current Azure PowerShell context.
 task getDeploymentIdentity -If { !$SkipGetDeploymentIdentity } -After InitCore {
 
@@ -35,7 +37,7 @@ task enableTemporaryNetworkAccess -If {$EnableTemporaryNetworkAccess} -Before Pr
         $script:TemporaryNetworkAccessRequiredResources[$i].Name = Resolve-Value $TemporaryNetworkAccessRequiredResources[$i].Name
     }
 
-    $script:__TEMPORARY_NETWORK_ACCESS_RULES__ = $true
+    Set-Variable -Name $_TEMP_NET_ACCESS_FLAG_NAME -Value $true -Scope Script
     Assert-TemporaryNetworkAccessRules -RequiredResources $TemporaryNetworkAccessRequiredResources
 }
 
@@ -46,7 +48,7 @@ $_cleanupTemporaryNetworkAccess = {
     if ($EnableTemporaryNetworkAccess -and (Test-Path variable:/__TEMPORARY_NETWORK_ACCESS_RULES__)) {
         Write-Build White "Removing temporary network access rules..."
         Assert-TemporaryNetworkAccessRules -RequiredResources $TemporaryNetworkAccessRequiredResources -Revoke
-        Remove-Item variable:/__TEMPORARY_NETWORK_ACCESS_RULES__ -Scope script -Force
+        Remove-Variable -Name $_TEMP_NET_ACCESS_FLAG_NAME -Scope Script -Force
     }
 }
 $script:OnExitActions.Add($_cleanupTemporaryNetworkAccess)

--- a/module/tasks/security.tasks.ps1
+++ b/module/tasks/security.tasks.ps1
@@ -29,6 +29,12 @@ task getDeploymentIdentity -If { !$SkipGetDeploymentIdentity } -After InitCore {
 
 # Synopsis: Apply temporary network access rules to the configured Azure resources.
 task enableTemporaryNetworkAccess -If {$EnableTemporaryNetworkAccess} -Before PreDeploy {
+    # support deferred evaluation for certain properties in 'TemporaryNetworkAccessRequiredResources'
+    for ($i=0; $i -lt $TemporaryNetworkAccessRequiredResources.Count; $i++) {
+        $script:TemporaryNetworkAccessRequiredResources[$i].ResourceGroupName = Resolve-Value $TemporaryNetworkAccessRequiredResources[$i].ResourceGroupName
+        $script:TemporaryNetworkAccessRequiredResources[$i].Name = Resolve-Value $TemporaryNetworkAccessRequiredResources[$i].Name
+    }
+
     $script:__TEMPORARY_NETWORK_ACCESS_RULES__ = $true
     Assert-TemporaryNetworkAccessRules -RequiredResources $TemporaryNetworkAccessRequiredResources
 }


### PR DESCRIPTION
- Add support for deferred evaluation of the `TemporaryNetworkAccessRequiredResources` property; this allows us to make these rules environment-specific by leveraging the existing ZF deployment configuration feature. For example:
  ```
  $TemporaryNetworkAccessRequiredResources = @(
    @{
        ResourceType = 'KeyVault'
        ResourceGroupName = { $deploymentConfig.ConfigurationResourceGroupName }
        Name = { $deploymentConfig.KeyVaultName }
    }
  )
  ```
- Refactor compensation logic for ensuring temporary network rules are removed, using the new mechanism available in [ZeroFailed.DevOps.Common](https://github.com/zerofailed/ZeroFailed.DevOps.Common/pull/6) 